### PR TITLE
Our use of EasyPost is not threadsafe the way we are setting the api token given sidekiq and is resulting in labels not being able to be generated in some cases

### DIFF
--- a/app/models/spree/easypost/address_decorator.rb
+++ b/app/models/spree/easypost/address_decorator.rb
@@ -1,7 +1,7 @@
 module Spree
   module EasyPost
     module AddressDecorator
-      def easypost_address
+      def easypost_address(easypost_api_key)
         attributes = {
           street1: address1,
           street2: address2,
@@ -17,7 +17,7 @@ module Spree
         attributes[:state] = state ? state.abbr : state_name
         attributes[:country] = country.try(:iso)
 
-        ::EasyPost::Address.create attributes
+        ::EasyPost::Address.create(attributes, easypost_api_key)
       end
     end
   end

--- a/app/models/spree/easypost/return_authorization.rb
+++ b/app/models/spree/easypost/return_authorization.rb
@@ -15,10 +15,13 @@ module Spree
 
       def easypost_shipment
         @ep_shipment ||= ::EasyPost::Shipment.create(
-          from_address: stock_location.easypost_address,
-          to_address: order.ship_address.easypost_address,
-          parcel: build_parcel,
-          is_return: true
+          {
+            from_address: stock_location.easypost_address(easypost_api_key),
+            to_address: order.ship_address.easypost_address(easypost_api_key),
+            parcel: build_parcel,
+            is_return: true
+          },
+          easypost_api_key
         )
       end
 
@@ -29,9 +32,14 @@ module Spree
 
       private
 
+      def easypost_api_key
+        order&.account&.easypost_api_key
+      end
+
       def build_parcel
         total_weight = inventory_units.joins(:variant).sum(:weight)
-        ::EasyPost::Parcel.create weight: total_weight
+
+        ::EasyPost::Parcel.create({ weight: total_weight }, easypost_api_key)
       end
     end
   end

--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -11,13 +11,17 @@ module Spree
 
     def retrieve_or_build_easypost_shipment
       if selected_easy_post_shipment_id
-        @ep_shipment ||= ::EasyPost::Shipment.retrieve(selected_easy_post_shipment_id)
+        @ep_shipment ||= ::EasyPost::Shipment.retrieve(selected_easy_post_shipment_id, easypost_api_key)
       else
         @ep_shipment = build_easypost_shipment
       end
     end
 
     private
+
+    def easypost_api_key
+      order&.account&.easypost_api_key
+    end
 
     def selected_easy_post_rate_id
       selected_shipping_rate.easy_post_rate_id
@@ -29,9 +33,12 @@ module Spree
 
     def build_easypost_shipment
       ::EasyPost::Shipment.create(
-        to_address: order.ship_address.easypost_address,
-        from_address: stock_location.easypost_address,
-        parcel: to_package.easypost_parcel
+        {
+          to_address: order.ship_address.easypost_address(easypost_api_key),
+          from_address: stock_location.easypost_address(easypost_api_key),
+          parcel: to_package.easypost_parcel
+        },
+        easypost_api_key
       )
     end
 

--- a/app/models/spree/stock/package_decorator.rb
+++ b/app/models/spree/stock/package_decorator.rb
@@ -6,15 +6,24 @@ module Spree
           item.quantity * item.variant.weight
         end
 
-        ::EasyPost::Parcel.create weight: total_weight
+        ::EasyPost::Parcel.create({ weight: total_weight }, easypost_api_key)
       end
 
       def easypost_shipment
         ::EasyPost::Shipment.create(
-          to_address: order.ship_address.easypost_address,
-          from_address: stock_location.easypost_address,
-          parcel: easypost_parcel
+          {
+            to_address: order.ship_address.easypost_address(easypost_api_key),
+            from_address: stock_location.easypost_address(easypost_api_key),
+            parcel: easypost_parcel
+          },
+          easypost_api_key
         )
+      end
+
+      private
+
+      def easypost_api_key
+        order&.account&.easypost_api_key
       end
     end
   end


### PR DESCRIPTION
TrackerUrl: https://www.pivotaltracker.com/story/show/172638418