### PR TITLE
Change the manner in which we prevent attempting to add duplicate Spree::ShippingMethods to a Store by first checking if that ShippingMethod is already present instead of relying on an duplicate index exception and rescuing it

### DIFF
--- a/app/models/solidus_easypost/estimator.rb
+++ b/app/models/solidus_easypost/estimator.rb
@@ -55,11 +55,7 @@ module SolidusEasyPost
         r.shipping_categories = [Spree::ShippingCategory.first]
       end
 
-      begin
-        store.shipping_methods << sm
-      rescue ActiveRecord::RecordNotUnique => e
-        # do nothing, this is to prevent duplicates
-      end
+      store.shipping_methods << sm unless store.shipping_methods.include?(sm)
 
       sm
     end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178558324