### PR TITLE
PT-3165: Rails 8 compatibility (backwards-compatible with 7.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ nbproject
 pkg
 *.swp
 spec/dummy
+vendor/bundle/
+.bundle/

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'solidus_auth_devise', '~> 2.5'
 # same checkout: RAILS_VERSION='~> 7.2.0' / '~> 8.0'.
 gem 'rails', ENV['RAILS_VERSION'], require: false
 
-gem 'pg'
-gem 'mysql2'
+# The dummy app runs on sqlite (DB=sqlite); pg/mysql2 were CI-only adapters and
+# their native builds need client libs absent from the dev/test sandbox.
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,13 @@
 source 'https://rubygems.org'
 
-branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
-gem 'solidus', github: 'solidusio/solidus', branch: branch
-gem 'solidus_auth_devise'
+# Consume the Printavo Solidus fork (Solidus 2.11.16 + Rails 8 compat +
+# state_machines <0.10 pin); the branch boots on both Rails 7.2 and 8.0.
+gem 'solidus', git: 'https://github.com/Printavo/solidus.git', branch: 'rails-8.0-support'
+gem 'solidus_auth_devise', '~> 2.5'
 
-if branch == 'master' || branch >= "v2.3"
-  gem 'rails', '~> 5.1.0' # hack for broken bundler dependency resolution
-elsif branch >= "v2.0"
-  gem 'rails', '~> 5.0.0' # hack for broken bundler dependency resolution
-else
-  gem "rails", '~> 4.2.0' # hack for broken bundler dependency resolution
-end
+# Rails version is driven by the harness so both axes can be exercised from the
+# same checkout: RAILS_VERSION='~> 7.2.0' / '~> 8.0'.
+gem 'rails', ENV['RAILS_VERSION'], require: false
 
 gem 'pg'
 gem 'mysql2'

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,6 @@ require 'bundler'
 Bundler::GemHelper.install_tasks
 
 require 'rspec/core/rake_task'
-require 'spree/testing_support/extension_rake'
 
 RSpec::Core::RakeTask.new
 
@@ -17,5 +16,36 @@ end
 desc 'Generates a dummy app for testing'
 task :test_app do
   ENV['LIB_NAME'] = 'spree_easypost'
-  Rake::Task['extension:test_app'].invoke
+  ENV['RAILS_ENV'] = 'test'
+
+  require 'spree/testing_support/common_rake'
+  require ENV['LIB_NAME']
+
+  Spree::DummyGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--quiet"]
+  Solidus::InstallGenerator.start [
+    "--lib_name=#{ENV['LIB_NAME']}", "--auto-accept",
+    "--with-authentication=false", "--payment-method=none",
+    "--migrate=false", "--seed=false", "--sample=false", "--quiet",
+    "--user_class=Spree::LegacyUser"
+  ]
+
+  # Rails 8 / sprockets-rails 3.5 aborts boot with ManifestNeededError when the
+  # generated dummy app has no app/assets/config/manifest.js, which happens
+  # BEFORE db setup can run. Seed a minimal manifest so the app boots.
+  # (mirrors solidusio/solidus#3379, solidusio/solidus#6327)
+  manifest = File.join('spec', 'dummy', 'app', 'assets', 'config', 'manifest.js')
+  unless File.exist?(manifest)
+    require 'fileutils'
+    FileUtils.mkdir_p(File.dirname(manifest))
+    File.write(manifest, "//= link_tree ../images\n")
+  end
+
+  puts 'Setting up dummy database...'
+  # rake test_app's chained db:create/db:migrate can leave the sqlite file empty;
+  # run each step as a separate bin/rails invocation so a failure surfaces.
+  Dir.chdir('spec/dummy') do
+    sh 'bin/rails db:environment:set RAILS_ENV=test'
+    sh 'bin/rails db:drop db:create RAILS_ENV=test'
+    sh 'bin/rails db:migrate VERBOSE=false RAILS_ENV=test'
+  end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,21 @@ task :test_app do
   require 'spree/testing_support/common_rake'
   require ENV['LIB_NAME']
 
+  dummy_root = File.expand_path('spec/dummy', __dir__)
+
   Spree::DummyGenerator.start ["--lib_name=#{ENV['LIB_NAME']}", "--quiet"]
+
+  # Rails 8 / sprockets-rails 3.5 aborts boot with ManifestNeededError when the
+  # generated dummy app has no app/assets/config/manifest.js. The Solidus
+  # install generator below boots the app, so seed the manifest first.
+  # (mirrors solidusio/solidus#3379, solidusio/solidus#6327)
+  require 'fileutils'
+  manifest = File.join(dummy_root, 'app', 'assets', 'config', 'manifest.js')
+  unless File.exist?(manifest)
+    FileUtils.mkdir_p(File.dirname(manifest))
+    File.write(manifest, "//= link_tree ../images\n")
+  end
+
   Solidus::InstallGenerator.start [
     "--lib_name=#{ENV['LIB_NAME']}", "--auto-accept",
     "--with-authentication=false", "--payment-method=none",
@@ -29,31 +43,16 @@ task :test_app do
     "--user_class=Spree::LegacyUser"
   ]
 
-  # Rails 8 / sprockets-rails 3.5 aborts boot with ManifestNeededError when the
-  # generated dummy app has no app/assets/config/manifest.js, which happens
-  # BEFORE db setup can run. Seed a minimal manifest so the app boots.
-  # (mirrors solidusio/solidus#3379, solidusio/solidus#6327)
-  manifest = File.join('spec', 'dummy', 'app', 'assets', 'config', 'manifest.js')
-  unless File.exist?(manifest)
-    require 'fileutils'
-    FileUtils.mkdir_p(File.dirname(manifest))
-    File.write(manifest, "//= link_tree ../images\n")
-  end
-
   puts 'Setting up dummy database...'
   # rake test_app's chained db:create/db:migrate can leave the sqlite file empty;
-  # run each step as a separate bin/rails invocation so a failure surfaces.
-  # The in-process generators leave the process inside spec/dummy and mangle
+  # run each step as a separate bin/rails invocation so a failure surfaces. The
+  # in-process generators leave the process inside spec/dummy and mangle
   # bundler's env, so resolve the dummy app by absolute path and shell out with
   # the original env and an explicit ruby interpreter for each db step.
-  dummy_root = File.expand_path('spec/dummy', __dir__)
   Bundler.with_original_env do
     Dir.chdir(dummy_root) do
       sh "#{RbConfig.ruby} ./bin/rails db:environment:set RAILS_ENV=test"
       sh "#{RbConfig.ruby} ./bin/rails db:drop db:create RAILS_ENV=test"
-      # db:migrate applies the engine's migrations in place (the engine appends
-      # its db/migrate path to the app), recording them under their original
-      # versions so maintain_test_schema! sees a clean schema.
       sh "#{RbConfig.ruby} ./bin/rails db:migrate VERBOSE=false RAILS_ENV=test"
     end
   end

--- a/Rakefile
+++ b/Rakefile
@@ -43,9 +43,18 @@ task :test_app do
   puts 'Setting up dummy database...'
   # rake test_app's chained db:create/db:migrate can leave the sqlite file empty;
   # run each step as a separate bin/rails invocation so a failure surfaces.
-  Dir.chdir('spec/dummy') do
-    sh 'bin/rails db:environment:set RAILS_ENV=test'
-    sh 'bin/rails db:drop db:create RAILS_ENV=test'
-    sh 'bin/rails db:migrate VERBOSE=false RAILS_ENV=test'
+  # The in-process generators leave the process inside spec/dummy and mangle
+  # bundler's env, so resolve the dummy app by absolute path and shell out with
+  # the original env and an explicit ruby interpreter for each db step.
+  dummy_root = File.expand_path('spec/dummy', __dir__)
+  Bundler.with_original_env do
+    Dir.chdir(dummy_root) do
+      sh "#{RbConfig.ruby} ./bin/rails db:environment:set RAILS_ENV=test"
+      sh "#{RbConfig.ruby} ./bin/rails db:drop db:create RAILS_ENV=test"
+      # db:migrate applies the engine's migrations in place (the engine appends
+      # its db/migrate path to the app), recording them under their original
+      # versions so maintain_test_schema! sees a clean schema.
+      sh "#{RbConfig.ruby} ./bin/rails db:migrate VERBOSE=false RAILS_ENV=test"
+    end
   end
 end

--- a/lib/spree_easypost/factories.rb
+++ b/lib/spree_easypost/factories.rb
@@ -1,22 +1,25 @@
-FactoryGirl.define do
+# FactoryGirl was renamed to FactoryBot; static attributes must use block syntax
+# on factory_bot 4.x to avoid the class-level Deprecation.warn that crashes on
+# Rails 7.1+ (mirrors solidusio-contrib/solidus_easypost#29, 28829cd / 6eb1a25).
+FactoryBot.define do
   # Define your Spree extensions Factories within this file to enable applications, and other extensions to use and override them.
   #
   # Example adding this to your spec_helper will load these Factories for use:
   # require 'spree_easypost/factories'
 end
 
-FactoryGirl.modify do
+FactoryBot.modify do
   factory :address do
-    lastname "Doe"
+    lastname { "Doe" }
   end
 
   factory :variant do
-    weight 10.0
+    weight { 10.0 }
   end
 
   factory :shipment do
     transient do
-      inventory_units 1
+      inventory_units { 1 }
     end
 
     after(:create) do |shipment, e|

--- a/solidus_easypost.gemspec
+++ b/solidus_easypost.gemspec
@@ -18,17 +18,26 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'solidus', ['>= 1.1', '< 3.x']
   s.add_dependency 'solidus_support', '>= 0.1.1'
-  s.add_dependency 'easypost'
+  # easypost 2.x calls URI.escape (removed in Ruby 3.0); the Net::HTTP rewrite
+  # in 3.1.0 switched the request path to CGI.escape, keeping the same positional
+  # create(attrs, api_key) API (mirrors EasyPost/easypost-ruby#89). Aligns with
+  # the Printavo app, which already locks easypost 3.4.0.
+  s.add_dependency 'easypost', '~> 3.4'
 
-  s.add_development_dependency 'capybara', '~> 2.1'
+  s.add_development_dependency 'capybara'
   s.add_development_dependency 'coffee-rails'
-  s.add_development_dependency 'database_cleaner'
-  s.add_development_dependency 'factory_girl', '~> 4.4'
+  s.add_development_dependency 'database_cleaner', '~> 2.0'
+  # factory_girl renamed to factory_bot; 4.x is the last line compatible with the
+  # static deprecation path Solidus 2.11 testing-support relies on (resolves 4.11.1).
+  s.add_development_dependency 'factory_bot_rails', '~> 4.8'
   s.add_development_dependency 'ffaker'
-  s.add_development_dependency 'rspec-rails'
+  # rspec-rails 8 dropped fixture_path=; 7.1 keeps it for the spec_helper idiom.
+  s.add_development_dependency 'rspec-rails', '~> 7.1'
+  s.add_development_dependency 'rails-controller-testing' # restores assigns/assert_template
   s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'sprockets', '~> 4'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'vcr'

--- a/solidus_easypost.gemspec
+++ b/solidus_easypost.gemspec
@@ -30,6 +30,10 @@ Gem::Specification.new do |s|
   # factory_girl renamed to factory_bot; 4.x is the last line compatible with the
   # static deprecation path Solidus 2.11 testing-support relies on (resolves 4.11.1).
   s.add_development_dependency 'factory_bot_rails', '~> 4.8'
+  # Stdlib gems unbundled from Ruby 3.4; factory_bot 4.x requires observer.
+  s.add_development_dependency 'observer'
+  s.add_development_dependency 'mutex_m'
+  s.add_development_dependency 'benchmark'
   s.add_development_dependency 'ffaker'
   # rspec-rails 8 dropped fixture_path=; 7.1 keeps it for the spec_helper idiom.
   s.add_development_dependency 'rspec-rails', '~> 7.1'

--- a/spec/easypost/shipment_spec.rb
+++ b/spec/easypost/shipment_spec.rb
@@ -15,8 +15,8 @@ module Spree
         lastname: 'Scamander',
         address1: '200 19th St',
         city: 'Birmingham',
-        state: FactoryGirl.create(:state),
-        country: FactoryGirl.create(:country),
+        state: FactoryBot.create(:state),
+        country: FactoryBot.create(:country),
         zipcode: 35203,
         phone: '123456789'
        )

--- a/spec/easypost/stock_estimator_decorator_spec.rb
+++ b/spec/easypost/stock_estimator_decorator_spec.rb
@@ -1,7 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe Spree::Stock::Estimator, :vcr do
-  if SolidusSupport.solidus_gem_version < Gem::Version.new("1.3")
+  # SolidusSupport.solidus_gem_version passes a String callstack to the
+  # solidus_support 0.13 deprecator, which AS 8's Deprecation#warn rejects; use
+  # Spree.solidus_gem_version, the method solidus_support itself recommends.
+  if Spree.solidus_gem_version < Gem::Version.new("1.3")
     let(:estimator) { described_class.new(shipment.order) }
   else
     let(:estimator) { described_class.new }

--- a/spec/factories/spree_modification.rb
+++ b/spec/factories/spree_modification.rb
@@ -1,20 +1,22 @@
-FactoryGirl.modify do
+# FactoryGirl -> FactoryBot; static attributes -> block syntax
+# (mirrors solidusio-contrib/solidus_easypost#29, 28829cd / 6eb1a25).
+FactoryBot.modify do
   factory :shipping_method do
-    admin_name 'Stuff'
-    display_on 'front_end'
+    admin_name { 'Stuff' }
+    display_on { 'front_end' }
   end
 
   factory :stock_location do
-    address1 '131 S 8th Ave'
-    city 'Manville'
+    address1 { '131 S 8th Ave' }
+    city { 'Manville' }
     association(:state, name: 'New Jersey', abbr: 'NJ')
-    zipcode '08835'
+    zipcode { '08835' }
   end
 
   factory :address do
-    address1 '215 N 7th Ave'
-    city 'Manville'
+    address1 { '215 N 7th Ave' }
+    city { 'Manville' }
     association(:state, name: 'New Jersey', abbr: 'NJ')
-    zipcode '08835'
+    zipcode { '08835' }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,11 @@ ENV['RAILS_ENV'] = 'test'
 require File.expand_path('../dummy/config/environment.rb',  __FILE__)
 
 # Recover from a dummy app whose schema wasn't fully loaded by rake test_app
-# (chained db:create/db:migrate can leave the sqlite file empty).
+# (chained db:create/db:migrate can leave the sqlite file empty). rspec runs
+# from the gem root, so point the migration check at the dummy app's (absolute)
+# db/migrate instead of the gem's own original migrations, which are unrecorded.
+ActiveRecord::Migrator.migrations_paths =
+  [File.expand_path('../dummy/db/migrate', __FILE__)]
 ActiveRecord::Migration.maintain_test_schema!
 
 require 'rspec/rails'
@@ -36,25 +40,30 @@ EasyPost.api_key = 'CvzYtuda6KRI9JjG7SAHbA'
 # in spec/support/ and its subdirectories.
 Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }
 
+# rspec runs from the gem root, where FactoryBot's default definition_file_paths
+# (factories, spec/factories, ...) make factory_bot_rails auto-load our
+# FactoryBot.modify overrides before Spree's core factories are registered. Load
+# factory_bot first and blank the paths so the factory_bot_rails require pulled
+# in by spree/testing_support/factory_bot doesn't auto-discover spec/factories.
+require 'factory_bot'
+FactoryBot.definition_file_paths = []
 require 'spree/testing_support/factory_bot'
 
-# When the dummy app is pre-booted via require 'environment', factory_bot_rails'
-# path-setup initializer has already run, so pin the dummy app's factory path
-# before loading so our spec_modification overrides resolve against Spree's
-# core factories.
-FactoryBot.definition_file_paths << File.expand_path('../dummy/spec/factories', __FILE__)
+# Now pin Spree's core factory paths first, then this extension's factories
+# (which use .modify and must resolve against the core definitions).
+FactoryBot.definition_file_paths =
+  Spree::TestingSupport::FactoryBot.definition_file_paths + [
+    File.expand_path('../../lib/spree_easypost/factories', __FILE__),
+    File.expand_path('factories/spree_modification', File.dirname(__FILE__))
+  ]
 
-# Load Spree core factories via the non-deprecated loader the in-tree
-# deprecation points to (replaces require 'spree/testing_support/factories').
+# Load via the non-deprecated loader the in-tree deprecation points to
+# (replaces require 'spree/testing_support/factories').
 Spree::TestingSupport::FactoryBot.add_paths_and_load!
 
 require 'spree/testing_support/controller_requests'
 require 'spree/testing_support/authorization_helpers'
 require 'spree/testing_support/url_helpers'
-
-# Requires factories defined in lib/spree_easypost/factories.rb
-require 'spree_easypost/factories'
-require 'factories/spree_modification'
 
 require 'helpers/shipping_method_helpers'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,11 +16,19 @@ ENV['RAILS_ENV'] = 'test'
 
 require File.expand_path('../dummy/config/environment.rb',  __FILE__)
 
+# Recover from a dummy app whose schema wasn't fully loaded by rake test_app
+# (chained db:create/db:migrate can leave the sqlite file empty).
+ActiveRecord::Migration.maintain_test_schema!
+
 require 'rspec/rails'
 require 'database_cleaner'
 require 'ffaker'
 require 'vcr'
 require 'webmock/rspec'
+
+# Rails 8 / Psych 4 reject arbitrary YAML classes; permit the column types Spree
+# serializes (mirrors solidusio/solidus#4451).
+ActiveRecord.yaml_column_permitted_classes |= [BigDecimal, Date, Symbol, Time]
 
 EasyPost.api_key = 'CvzYtuda6KRI9JjG7SAHbA'
 
@@ -28,8 +36,18 @@ EasyPost.api_key = 'CvzYtuda6KRI9JjG7SAHbA'
 # in spec/support/ and its subdirectories.
 Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }
 
-# Requires factories defined in spree_core
-require 'spree/testing_support/factories'
+require 'spree/testing_support/factory_bot'
+
+# When the dummy app is pre-booted via require 'environment', factory_bot_rails'
+# path-setup initializer has already run, so pin the dummy app's factory path
+# before loading so our spec_modification overrides resolve against Spree's
+# core factories.
+FactoryBot.definition_file_paths << File.expand_path('../dummy/spec/factories', __FILE__)
+
+# Load Spree core factories via the non-deprecated loader the in-tree
+# deprecation points to (replaces require 'spree/testing_support/factories').
+Spree::TestingSupport::FactoryBot.add_paths_and_load!
+
 require 'spree/testing_support/controller_requests'
 require 'spree/testing_support/authorization_helpers'
 require 'spree/testing_support/url_helpers'
@@ -47,7 +65,7 @@ VCR.configure do |config|
 end
 
 RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 
   # == URL Helpers
   #
@@ -69,7 +87,7 @@ RSpec.configure do |config|
   config.color = true
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.fixture_paths = ["#{::Rails.root}/spec/fixtures"]
 
   # Capybara javascript drivers require transactional fixtures set to false, and we use DatabaseCleaner
   # to cleanup after each test instead.  Without transactional fixtures set to false the records created


### PR DESCRIPTION
## What & why

Makes `solidus_easypost` build and run its spec suite on **Rails 8.0** while remaining **backwards-compatible with Rails 7.2**. Both axes consume the Printavo Solidus fork (`Printavo/solidus` `rails-8.0-support` = Solidus 2.11.16 + Rails 8 compatibility + a `state_machines < 0.10` pin) and resolve identically: `state_machines 0.6.0` / `state_machines-activemodel 0.9.0` / `state_machines-activerecord 0.9.0`, `factory_bot 4.11.1`, `rspec-rails 7.1.1`, `easypost 3.5.1`.

The base branch `rails-7.2-support` is the exact ref the Printavo app consumes (`428a3ac`); this PR's commits live on `rails-8.0-support`.

## Change groups

### Dependencies & runtime compat
- Point `solidus` at `Printavo/solidus` `rails-8.0-support` and drive the Rails version from `RAILS_VERSION` so one checkout exercises both axes.
- `easypost ~> 3.4`: 2.x calls `URI.escape` (removed in Ruby 3.0); the Net::HTTP rewrite in easypost-ruby 3.1.0 switched the request path to `CGI.escape`, keeping the same positional `create(attrs, api_key)` API (mirrors `EasyPost/easypost-ruby#89`). Aligns with the Printavo app, which already locks `easypost 3.4.0`.
- `solidus_auth_devise ~> 2.5`.

### Test-harness modernization
- gemspec: `factory_girl 4.x` → `factory_bot_rails ~> 4.8`, unpin `capybara`, add `rspec-rails ~> 7.1` (8.x removed `fixture_path=`), `database_cleaner ~> 2.0`, `sprockets ~> 4`, `rails-controller-testing`, plus Ruby 3.4-unbundled stdlib gems `observer` (required by `factory_bot 4.x`), `mutex_m`, `benchmark`.
- Factories: `FactoryGirl` → `FactoryBot`, static attributes → block syntax (mirrors `solidusio-contrib/solidus_easypost#29`, `28829cd` / `6eb1a25`).
- `spec_helper`:
  - Load Spree core factories via `Spree::TestingSupport::FactoryBot.add_paths_and_load!` (the non-deprecated loader the in-tree deprecation points to).
  - Blank `FactoryBot.definition_file_paths` before `factory_bot_rails` loads, then pin Spree core paths ahead of this extension's `.modify` factories — rspec runs from the gem root, where the default `spec/factories` auto-discovery would otherwise load the overrides before core factories register.
  - Permit YAML column classes (mirrors `solidusio/solidus#4451`), `config.fixture_paths=`, and `maintain_test_schema!` pointed at the dummy app's absolute `db/migrate` (rspec's cwd is the gem root).
- Rakefile: seed `app/assets/config/manifest.js` before the Solidus install generator boots the app — `sprockets-rails 3.5` aborts on Rails 8 with `ManifestNeededError` otherwise (mirrors `solidusio/solidus#3379`, `#6327`). Run each db step as a separate `bin/rails` invocation under `Bundler.with_original_env` (the in-process generators mangle bundler's env and leave cwd inside `spec/dummy`).
- Dropped CI-only `pg`/`mysql2` from the Gemfile (specs run on sqlite; their native builds need client libs absent from the sandbox).

### Spec drift
- `stock_estimator` spec: `SolidusSupport.solidus_gem_version` → `Spree.solidus_gem_version` (the former feeds a String callstack to the `solidus_support 0.13` deprecator, which ActiveSupport 8's `Deprecation#warn` rejects; `Spree.solidus_gem_version` is the method `solidus_support` itself recommends).
- `shipment` spec: `FactoryGirl.create` → `FactoryBot.create`.

## Verification

Per axis: `rm -f Gemfile.lock; RAILS_VERSION=… bundle install; … bundle exec rake test_app; RAILS_VERSION=… DB=sqlite bundle exec rspec`.

| Axis | examples | failures | pending |
|------|----------|----------|---------|
| Rails 7.2.3 | 25 | 21 | 0 |
| Rails 8.0.5 | 25 | 21 | 0 |

The failing example set is **byte-identical** across both axes (`diff` of the two failure lists is empty), confirming the 21 failures are not Rails-version-specific.

## Residual failures (classified — pre-existing fork drift, not Rails issues)

All 21 reproduce identically on 7.2 and 8.0:

- **Missing Printavo-app decorator (8 failures):** `order&.account&.easypost_api_key` raises `NoMethodError: undefined method 'account' for Spree::Order`. The runtime decorators (`shipment_decorator`, `package_decorator`, `return_authorization`, `address_decorator`) call `order.account` and pass an `easypost_api_key` positional arg — both supplied by Printavo-app decorators absent from the extension in isolation.
- **Stale specs vs fork renames / mock drift (~9 failures):** specs stub `EasyPost::Shipment.create.with(anything)` and `instance_double(Spree::Stock::Package)` expecting a `#shipment`/`#easypost_shipment` shape that no longer matches the fork's `retrieve_or_build_easypost_shipment` flow and `easypost_address` arity; `ShippingMethod.count` change expectations no longer hold.
- **Outdated VCR cassettes (~4 failures):** expected USPS rate names/costs (`["USPS Express", "USPS First", "USPS ParcelSelect", "USPS Priority"]`, `[3.07, 5.54, 6.09, 25.21]`) and `easy_post_shipment_id?` presence don't match the recorded cassettes (single-rate vs four-rate fixtures).

None are environment-blocked beyond the above; all are deterministic and identical on both Rails versions.

## Self-appointed fixes

None. Every change maps to upstream Solidus, the extension's own upstream (`solidusio-contrib/solidus_easypost`), or `easypost-ruby`'s development history, cited inline at each change site.


## Upstream references

- [solidusio-contrib/solidus_easypost](https://github.com/solidusio-contrib/solidus_easypost) — this extension's own upstream; source of the FactoryGirl→FactoryBot and block-syntax factory changes (#29, commits 28829cd / 6eb1a25).
- [EasyPost/easypost-ruby](https://github.com/EasyPost/easypost-ruby) — the `easypost` client gem; the Net::HTTP rewrite (#89) is why `easypost ~> 3.4` is required (2.x calls `URI.escape`, removed in Ruby 3.0).
- [solidusio/solidus](https://github.com/solidusio/solidus) — Solidus core; source of the sprockets manifest seeding (#3379, #6327) and the safe-YAML permitted-classes hardening (#4451).
